### PR TITLE
Load version and url info of dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.2
+
+- Added support for loading version and url info of dependency from `.xcodeproj` file
+
+- Added support for loading version and url info of dependency from `.xcworkspace` file
+
+## 0.1
+
+- Load licenses from `Derived Data` folder from the dependency repo that SPM checks out locally

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ As part of an Xcode target's 'Run Script' build phase:
 
 ### Notes
 
-- If both options are specified, `-w` will be ignored 
-
-- `libraryName` is the name of the repo and `name` is the name of the SPM Package as defined be the dependency in `Package.swift` 
-
-- `text` field will be missing if a dependency does not provice a license file at the root of the repo
+- If both the project (`-p`) and workspace (`-w`) arguments are specified, then the workspace (`-w`) will be ignored
 
 ## Output Format
+
+- `libraryName` is the name of the repo and `name` is the name of the SPM Package as defined as defined in the dependency's `Package.swift`
+
+- `text` field will be missing if a dependency does not provide a license file at the root of the repo
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 * Python 3
 * Swift Package Manager dependencies only
-* Tested with Xcode 11.3.1
+* Tested with Xcode 13.0
 
 ## Usage Example
 
@@ -10,14 +10,31 @@ As part of an Xcode target's 'Run Script' build phase:
 
 `$SRCROOT/generate-licenses.py --build-dir $BUILD_DIR --output-file $SRCROOT/licenses.json`
 
+### Additional Params
+
+- Use `-p $PROJECT_DIR/ProjectName.xcodeproj` to load the version and url info from `Package.resolved` in the project
+
+- Use `-w $PROJECT_DIR/WorkspaceName.xcworkspace` to load the version and url info from `Package.resolved` file in the workspace
+
+### Notes
+
+- If both options are specified, `-w` will be ignored 
+
+- `libraryName` is the name of the repo and `name` is the name of the SPM Package as defined be the dependency in `Package.swift` 
+
+- `text` field will be missing if a dependency does not provice a license file at the root of the repo
 
 ## Output Format
+
 ```json
 {
     "licenses": [
         {
             "libraryName": "",
-            "text": ""
+            "text": "",
+            "name": "",
+            "version": "",
+            "url": ""
         },
         {
             ...

--- a/generate-licenses.py
+++ b/generate-licenses.py
@@ -5,7 +5,7 @@
     Generate a single .json file with the licenses for
     all Swift Package Manager dependencies of an Xcode Project.
 
-    :usage: ./licenses.py -b $BUILD_DIR -o licenses.json
+    :usage: ./licenses.py -b $BUILD_DIR -p $PROJECT_DIR/ProjectName.xcodeproj -o $SRCROOT/licenses.json
 
     :author: Seb Jachec (https://twitter.com/iamsebj)
 '''
@@ -16,6 +16,7 @@ from glob import glob
 import json
 import os.path
 from sys import argv
+import urlparse
 
 
 __version__ = '0.1'
@@ -34,6 +35,14 @@ def output_file_type(string):
             'Output file path must contain .json extension')
     return string
 
+def xcode_proj_type(string):
+    if not os.path.isdir(string):
+        raise ArgumentTypeError('Invalid project path: % s' % string)
+    if '.xcodeproj' not in string:
+        raise ArgumentTypeError(
+            'Invalid --project_file argument: % s' % string)
+    return string
+
 
 def main(_):
     parser = ArgumentParser(description=DESCRIPTION)
@@ -47,6 +56,11 @@ def main(_):
                         metavar='output_file',
                         help='path to the .json licenses file to be generated',
                         type=output_file_type)
+    parser.add_argument('-p', '--project-file',
+                        dest='project_file',
+                        metavar='project_file',
+                        help='path to the .xcodeproj',
+                        type=xcode_proj_type)
     parser.add_argument('--version', action='version',
                         version='%(prog)s {version}'.format(version=__version__))
 
@@ -57,9 +71,15 @@ def main(_):
 
     licenses_search_dir = packages_checkouts_dir(args.build_dir_path)
     data = licenses_from_dir(licenses_search_dir)
+    licenses_info = data
+
+    package_path = resolved_package_path(args.project_file)
+    packages = list(map(dependency_from_resolved_package, load_resolved_packages(package_path)))
+
+    update_packages_with_licenses(packages, licenses_info)
 
     with open(args.output_file, 'w') as output_file:
-        json.dump(data, output_file, ensure_ascii=False, indent=4)
+        json.dump({'licenses': packages}, output_file, ensure_ascii=False, indent=4)
 
     return 0
 
@@ -69,12 +89,15 @@ def packages_checkouts_dir(build_directory):
     checkouts_dir = os.path.join(derived_data_dir, 'SourcePackages', 'checkouts')
     return checkouts_dir
 
+def resolved_package_path(proj_directory):
+    # Check *.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+    package_path = os.path.join(proj_directory, 'project.xcworkspace', 'xcshareddata', 'swiftpm', 'Package.resolved')
+    return package_path
+
 def licenses_from_dir(directory):
     license_paths = license_paths_from_dir(directory)
 
-    return {
-        'licenses': list(map(license_dict_from_file, license_paths))
-    }
+    return list(map(license_dict_from_file, license_paths))
 
 
 def is_license_file(path):
@@ -98,6 +121,35 @@ def license_dict_from_file(path):
         'libraryName': parent_directory_name,
         'text': text
     }
+
+def load_resolved_packages(path):
+    with open(path, 'r') as file:
+        text = file.read()
+
+    packages_data = json.loads(text)
+    return packages_data['object']['pins']
+
+def dependency_from_resolved_package(package):
+    return {
+        'name': package['package'],
+        'version': package['state']['version'],
+        'url': package['repositoryURL']
+        }
+
+def extract_repo_name_from_url(url):
+    url_components = urlparse.urlparse(url)
+    path = url_components.path
+    repo_name = path.rpartition('/')[-1].replace('.git', '')
+    return repo_name
+
+def update_packages_with_licenses(packages, licenses_info):
+    for package in packages:
+        url = package['url']
+        repo_name = extract_repo_name_from_url(url)
+        matchingLicenseInfo = filter(lambda x: x['libraryName'] == repo_name, licenses_info)
+        if matchingLicenseInfo:
+            package['text'] = matchingLicenseInfo[0]['text']
+            package['libraryName'] = matchingLicenseInfo[0]['libraryName']
 
 
 if __name__ == '__main__':

--- a/generate-licenses.py
+++ b/generate-licenses.py
@@ -82,7 +82,7 @@ def main(_):
 
     args = parser.parse_args()
 
-    # Read all licenses from dervied data folder where SPM has checked out the source for each one
+    # Read all licenses from derived data folder where SPM has checked out the source for each one
     licenses_search_dir = packages_checkouts_dir(args.build_dir_path)
     licenses_info = licenses_from_dir(licenses_search_dir)
 


### PR DESCRIPTION
Added support for users to pass in the path to `.xcodeproj` or `.xcworkspace` file where Xcode creates `Package.resolved` file which contains the version and url info for all dependencies

The script then merges the license info with this additional info to provide more details about the dependencies